### PR TITLE
Fixed a formula mistake.

### DIFF
--- a/Tutorial4/Tutorial4.ipynb
+++ b/Tutorial4/Tutorial4.ipynb
@@ -263,7 +263,7 @@
     "U = \n",
     "\\begin{bmatrix}\n",
     "u_0(0) & u_1(0) & \\dots & u_{N-1}(0)\\\\\n",
-    "u_0(1) & u_1(0) & \\dots & u_{N-1}(1)\\\\\n",
+    "u_0(1) & u_1(1) & \\dots & u_{N-1}(1)\\\\\n",
     "\\vdots & \\vdots& & \\vdots\\\\\n",
     "u_0(N-1) & u_1(N-1) & \\dots & u_{N-1}(N-1)\\\\\n",
     "\\end{bmatrix} \n",


### PR DESCRIPTION
In section 'Definition of Fourier transform', the element at row2 col2
should have the variable of 1 instead of 0.